### PR TITLE
📦 Bump npm:tar-fs:2.0.1 to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
     "docker-modem": "^3.0.0",
-    "tar-fs": "~2.0.1"
+    "tar-fs": "2.1.3"
   },
   "devDependencies": {
     "bluebird": "^3.7.0",


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:

| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2025-48387 | High  | tar-fs provides filesystem bindings for tar-stream. Versions prior to 3.0.9, 2.1.3, and 1.16.5 have an issue where an extract can write outside the specified dir with a specific tarball. This has been patched in versions 3.0.9, 2.1.3, and 1.16.5. As a workaround, use the ignore option to ignore non files/directories. |
| CVE-2024-12905 | High  | An Improper Link Resolution Before File Access ("Link Following") and Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal"). This vulnerability occurs when extracting a maliciously crafted tar file, which can result in unauthorized file writes or overwrites outside the intended extraction directory. The issue is associated with index.js in the tar-fs package.  This issue affects tar-fs: from 0.0.0 before 1.16.4, from 2.0.0 before 2.1.2, from 3.0.0 before 3.0.8. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket: